### PR TITLE
Add Retri3D neural representation retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 
 - [PointNet: Deep Learning on Point Sets for 3D Classification and Segmentation (2017)](https://arxiv.org/abs/1612.00593) - A deep learning model for 3D point cloud processing.
 - [NeRF: Neural Radiance Fields for View Synthesis (2020)](https://arxiv.org/abs/2003.08934) - A model for representing 3D scenes using neural networks.
+- [Retri3D: 3D Neural Graphics Representation Retrieval (2025)](https://openreview.net/forum?id=q3EbOXb4y1) - Retrieves pretrained NeRF and 3D Gaussian Splatting representations without access to their original training data.
 - [Open3D](http://www.open3d.org/) - An open-source library for 3D data processing and visualization.
 - [Colmap](https://colmap.github.io/) - A general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline.
 


### PR DESCRIPTION
## Summary

- add the ICLR 2025 Spotlight paper Retri3D to the 3D computer vision section
- describe its retrieval of pretrained NeRF and 3D Gaussian Splatting representations

## Checks

- confirmed Retri3D is absent from the default branch and existing issues/PRs
- kept the change to one concise README entry in the existing style
- verified the OpenReview link

## Disclosure

I am submitting this on behalf of paper co-author Yuxuan Zhang.
